### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ pycparser==2.20
 Pygments==2.17.2
 pyparsing==2.4.7
 readme-renderer==42.0
-requests==2.25.1
+requests>=2.25.1
 requests-toolbelt==0.9.1
 rfc3986==1.4.0
 rich==13.7.0


### PR DESCRIPTION
If the application already has the requests module installed with a version higher than 2.25.1, an error occurs:
**ModuleNotFoundError: No module named 'requests'**